### PR TITLE
Reponse error when send batch sms is fixed

### DIFF
--- a/src/response/sms/SmsSendBatchResponse.php
+++ b/src/response/sms/SmsSendBatchResponse.php
@@ -19,7 +19,7 @@ class SmsSendBatchResponse extends AbstractResponse
     {
         $this->message = $client->getResponse()->message;
         if ($client->getStatusCode() === 200) {
-            $this->status = (string)$client->getResponse()->status;
+            $this->status = (string)$client->getResponse()->status[0];
             $this->isSuccess = true;
         }
     }


### PR DESCRIPTION
Eskizga batch formatida smslar yuborganda, responsedagi status array ko'rinishda qaytmoqda. Shuning uchun responsega o'zgartirish kiritib, statusdagi birinchi element string sifatida qaytariladigan bo'ldi